### PR TITLE
Add self-closing assets tag support

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,8 +1,8 @@
 <x-laravel-base::layouts.html :title="$title ?? ''" {{ $attributes }}>
-    <x-slot:headTop>
+    <x-slot:head-top>
         {{ $headTop ?? '' }}
         @stack('head-top')
-    </x-slot:headTop>
+    </x-slot:head-top>
 
     <x-slot:head>
         @if ($livewire)
@@ -24,7 +24,7 @@
     @endif
 
     @if ($assets)
-        @lbJavaScript
+        <lb:scripts />
     @endif
 
     {{ $js ?? '' }}

--- a/src/LaravelBaseServiceProvider.php
+++ b/src/LaravelBaseServiceProvider.php
@@ -31,6 +31,7 @@ use Rawilk\LaravelBase\Models\AuthenticatorApp;
 use Rawilk\LaravelBase\Services\Auth\CustomSessionGuard;
 use Rawilk\LaravelBase\Services\Auth\SessionImpersonator;
 use Rawilk\LaravelBase\Services\Files\SizeUnitFactor;
+use Rawilk\LaravelBase\Support\BaseTagCompiler;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -165,6 +166,14 @@ class LaravelBaseServiceProvider extends PackageServiceProvider
 
     protected function bootDirectives(): void
     {
+        // Our custom tag compiler will allow us to use self-closing tags instead of a directive,
+        // i.e. <lb:javaScript /> instead of @lbJavaScript.
+        if (method_exists($this->app['blade.compiler'], 'precompiler')) {
+            $this->app['blade.compiler']->precompiler(function ($string) {
+                return app(BaseTagCompiler::class)->compile($string);
+            });
+        }
+
         Blade::directive('lbJavaScript', function (string $expression) {
             return "<?php echo \\Rawilk\\LaravelBase\\Facades\\LaravelBaseAssets::javaScript({$expression}); ?>";
         });

--- a/src/Services/Assets.php
+++ b/src/Services/Assets.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Rawilk\LaravelBase\Services;
 
+use function config;
+use function rtrim;
+
 final class Assets
 {
     public function javaScript(array $options = []): string
@@ -17,12 +20,12 @@ final class Assets
 
     private function javaScriptAssets(array $options = []): string
     {
-        $appUrl = config('laravel-base.asset_url', rtrim($options['asset_url'] ?? '', '/'));
+        $assetsUrl = config('laravel-base.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
 
         $manifest = json_decode(file_get_contents(__DIR__ . '/../../dist/mix-manifest.json'), true);
         $versionedFileName = ltrim($manifest['/assets/laravel-base.js'], '/');
 
-        $fullAssetPath = "{$appUrl}/laravel-base/{$versionedFileName}";
+        $fullAssetPath = "{$assetsUrl}/laravel-base/{$versionedFileName}";
 
         return <<<HTML
         <script src="{$fullAssetPath}" data-turbolinks-eval="false" data-turbo-eval="false"></script>

--- a/src/Support/BaseTagCompiler.php
+++ b/src/Support/BaseTagCompiler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Support;
+
+use Illuminate\View\Compilers\ComponentTagCompiler;
+
+class BaseTagCompiler extends ComponentTagCompiler
+{
+    public function compile($value)
+    {
+        return $this->compileFormComponentsSelfClosingTags($value);
+    }
+
+    protected function compileFormComponentsSelfClosingTags($value): array|string|null
+    {
+        $pattern = "/
+            <
+                \s*
+                lb\:([\w\-\:\.]*)
+                \s*
+                (?<attributes>
+                    (?:
+                        \s+
+                        [\w\-:.@]+
+                        (
+                            =
+                            (?:
+                                \\\"[^\\\"]*\\\"
+                                |
+                                \'[^\']*\'
+                                |
+                                [^\'\\\"=<>]+
+                            )
+                        )?
+                    )*
+                    \s*
+                )
+            \/?>
+        /x";
+
+        return preg_replace_callback($pattern, function (array $matches) {
+            $component = $matches[1];
+
+            if ($component === 'javaScript' || $component === 'scripts') {
+                return '@lbJavaScript';
+            }
+
+            return '';
+        }, $value);
+    }
+}

--- a/tests/Unit/AssetsDirectiveTest.php
+++ b/tests/Unit/AssetsDirectiveTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\LaravelBase\Facades\LaravelBaseAssets;
+
+it('outputs the script source', function () {
+    $this->assertStringContainsString(
+        '<script src="/laravel-base/assets/laravel-base.js?',
+        LaravelBaseAssets::javaScript(),
+    );
+});
+
+it('outputs a comment when app is in debug mode', function () {
+    config()->set('app.debug', true);
+
+    $this->assertStringContainsString(
+        '<!-- LaravelBase Scripts -->',
+        LaravelBaseAssets::javaScript(),
+    );
+});
+
+it('does not output a comment when not in debug mode', function () {
+    config()->set('app.debug', false);
+
+    $this->assertStringNotContainsString(
+        '<!-- LaravelBase Scripts -->',
+        LaravelBaseAssets::javaScript(),
+    );
+});
+
+it('can set a custom asset url', function () {
+    config()->set('laravel-base.asset_url', 'https://example.com');
+
+    $this->assertStringContainsString(
+        '<script src="https://example.com/laravel-base/assets/laravel-base.js?',
+        LaravelBaseAssets::javaScript(),
+    );
+});
+
+it('accepts an asset url as an argument', function () {
+    $this->assertStringContainsString(
+        '<script src="https://example.com/laravel-base/assets/laravel-base.js?',
+        LaravelBaseAssets::javaScript(['asset_url' => 'https://example.com']),
+    );
+});

--- a/tests/Unit/TagCompilerTest.php
+++ b/tests/Unit/TagCompilerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\LaravelBase\Support\BaseTagCompiler;
+
+beforeEach(function () {
+    $this->compiler = new BaseTagCompiler;
+});
+
+it('compiles the scripts tag', function (string $tag) {
+    $result = $this->compiler->compile($tag);
+
+    expect('@lbJavaScript')->toBe($result);
+})->with([
+    '<lb:scripts />',
+    '<lb:javaScript />',
+]);


### PR DESCRIPTION
Instead of adding the package's scripts to the DOM via `@lbJavaScript`, this PR adds support for doing it through a self-closing tag.

```html
<lb:scripts />

<!-- or -->

<lb:javaScript />
```
