### PR TITLE
Content Security Policy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
             "Rawilk\\LaravelBase\\": "src"
         },
         "files": [
-            "src/helpers.php"
+            "src/helpers.php",
+            "src/Csp/helpers.php"
         ]
     },
     "autoload-dev": {

--- a/config/csp.php
+++ b/config/csp.php
@@ -1,0 +1,60 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Policy
+    |--------------------------------------------------------------------------
+    |
+    | A policy will determine which CSP headers will be set. A valid CSP policy
+    | is any class that extends `Rawilk\LaravelBase\Csp\Policies\CspPolicy`
+    |
+    */
+    'policy' => \Rawilk\LaravelBase\Csp\Policies\BasicCsp::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Report Only
+    |--------------------------------------------------------------------------
+    |
+    | The policy will be put into report only mode. This is great for testing
+    | out a new policy or changes to an existing csp policy without breaking
+    | anything.
+    |
+    */
+    'report_only' => env('CSP_REPORT_ONLY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Report URI
+    |--------------------------------------------------------------------------
+    |
+    | All violations against the policy will be reported to this url.
+    | A great service you could use for this is https://report-uri.com/
+    |
+    | You can override this setting by calling `reportTo` on your policy.
+    |
+    */
+    'report_uri' => env('CSP_REPORT_URI'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enabled
+    |--------------------------------------------------------------------------
+    |
+    | CSP headers will only be added if this is set to true.
+    |
+    */
+    'enabled' => env('CSP_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Nonce Generator
+    |--------------------------------------------------------------------------
+    |
+    | This class is responsible for generating the nonces used in inline
+    | tags and headers.
+    |
+    */
+    'nonce_generator' => \Rawilk\LaravelBase\Csp\Nonce\ViteNonceGenerator::class,
+];

--- a/src/Csp/Enums/CspDirective.php
+++ b/src/Csp/Enums/CspDirective.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Enums;
+
+enum CspDirective: string
+{
+    case Base = 'base-uri';
+    case BlockAllMixedContent = 'block-all-mixed-content';
+    case Child = 'child-src';
+    case Connect = 'connect-src';
+    case Default = 'default-src';
+    case Font = 'font-src';
+    case FormAction = 'form-action';
+    case Frame = 'frame-src';
+    case FrameAncestors = 'frame-ancestors';
+    case Img = 'img-src';
+    case Manifest = 'manifest-src';
+    case Media = 'media-src';
+    case Object = 'object-src';
+    case Plugin = 'plugin-types';
+    case Prefetch = 'prefetch-src';
+    case Report = 'report-uri';
+    case ReportTo = 'report-to';
+    case Sandbox = 'sandbox';
+    case Script = 'script-src';
+    case ScriptAttr = 'script-src-attr';
+    case ScriptElem = 'script-src-elem';
+    case Style = 'style-src';
+    case StyleAttr = 'style-src-attr';
+    case StyleElem = 'style-src-elem';
+    case UpgradeInsecureRequests = 'upgrade-insecure-requests';
+    case WebRtc = 'webrtc-src';
+    case Worker = 'worker-src';
+}

--- a/src/Csp/Enums/CspKeyword.php
+++ b/src/Csp/Enums/CspKeyword.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Enums;
+
+enum CspKeyword: string
+{
+    case None = 'none';
+    case ReportSample = 'report-sample';
+    case Self = 'self';
+    case StrictDynamic = 'strict-dynamic';
+    case UnsafeEval = 'unsafe-eval';
+    case UnsafeHashes = 'unsafe-hashes';
+    case UnsafeInline = 'unsafe-inline';
+}

--- a/src/Csp/Enums/CspScheme.php
+++ b/src/Csp/Enums/CspScheme.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Enums;
+
+enum CspScheme: string
+{
+    case Blob = 'blob:';
+    case Data = 'data:';
+    case Http = 'http:';
+    case Https = 'https:';
+    case Ws = 'ws:';
+    case Wss = 'wss:';
+}

--- a/src/Csp/Enums/CspValue.php
+++ b/src/Csp/Enums/CspValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Enums;
+
+abstract class CspValue
+{
+    public const NO_VALUE = false;
+}

--- a/src/Csp/Middleware/AddCspHeaders.php
+++ b/src/Csp/Middleware/AddCspHeaders.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Rawilk\LaravelBase\Csp\PolicyFactory;
+
+class AddCspHeaders
+{
+    public function handle(Request $request, Closure $next, string $customPolicyClass = null): mixed
+    {
+        $response = $next($request);
+
+        $this
+            ->getPolicies($customPolicyClass)
+            ->filter->shouldBeApplied($request, $response)
+            ->each->applyTo($response);
+
+        return $response;
+    }
+
+    protected function getPolicies(string $customPolicyClass = null): Collection
+    {
+        $policies = collect();
+
+        if ($customPolicyClass) {
+            $policies->push(PolicyFactory::create($customPolicyClass));
+
+            return $policies;
+        }
+
+        $policyClass = config('csp.policy');
+
+        if (! empty($policyClass)) {
+            $policy = PolicyFactory::create($policyClass);
+
+            $reportOnly = config('csp.report_only');
+
+            if ($reportOnly) {
+                $policy->reportOnly();
+            }
+
+            $policies->push($policy);
+        }
+
+        return $policies;
+    }
+}

--- a/src/Csp/Nonce/NonceGenerator.php
+++ b/src/Csp/Nonce/NonceGenerator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rawilk\LaravelBase\Csp\Nonce;
+
+interface NonceGenerator
+{
+    public function generate(): string;
+}

--- a/src/Csp/Nonce/RandomStringNonceGenerator.php
+++ b/src/Csp/Nonce/RandomStringNonceGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Nonce;
+
+use Illuminate\Support\Str;
+
+class RandomStringNonceGenerator implements NonceGenerator
+{
+    public function generate(): string
+    {
+        return Str::random(32);
+    }
+}

--- a/src/Csp/Nonce/ViteNonceGenerator.php
+++ b/src/Csp/Nonce/ViteNonceGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Nonce;
+
+use Illuminate\Support\Facades\Vite;
+
+class ViteNonceGenerator implements NonceGenerator
+{
+    public function generate(): string
+    {
+        return Vite::useCspNonce();
+    }
+}

--- a/src/Csp/Policies/BasicCsp.php
+++ b/src/Csp/Policies/BasicCsp.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Policies;
+
+use Rawilk\LaravelBase\Csp\Enums\CspDirective;
+use Rawilk\LaravelBase\Csp\Enums\CspKeyword;
+
+class BasicCsp extends CspPolicy
+{
+    public function configure(): void
+    {
+        $this
+            ->addDirective(CspDirective::Base, CspKeyword::Self)
+            ->addDirective(CspDirective::Connect, CspKeyword::Self)
+            ->addDirective(CspDirective::Default, CspKeyword::Self)
+            ->addDirective(CspDirective::FormAction, CspKeyword::Self)
+            ->addDirective(CspDirective::Img, CspKeyword::Self)
+            ->addDirective(CspDirective::Media, CspKeyword::Self)
+            ->addDirective(CspDirective::Object, CspKeyword::None)
+            ->addDirective(CspDirective::Script, CspKeyword::Self)
+            ->addDirective(CspDirective::Style, CspKeyword::Self)
+            ->addNonceForDirective(CspDirective::Script)
+            ->addNonceForDirective(CspDirective::Style);
+    }
+}

--- a/src/Csp/Policies/CspPolicy.php
+++ b/src/Csp/Policies/CspPolicy.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp\Policies;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Rawilk\LaravelBase\Csp\Enums\CspDirective;
+use Rawilk\LaravelBase\Csp\Enums\CspKeyword;
+use Rawilk\LaravelBase\Csp\Enums\CspScheme;
+use Rawilk\LaravelBase\Csp\Enums\CspValue;
+use Rawilk\LaravelBase\Exceptions\InvalidCspDirective;
+use Rawilk\LaravelBase\Exceptions\InvalidCspValueSet;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class CspPolicy
+{
+    protected array $directives = [];
+
+    protected bool $reportOnly = false;
+
+    abstract public function configure(): void;
+
+    public function addDirective(string|CspDirective $directive, string|array|bool|CspKeyword|CspScheme $values): self
+    {
+        $this->guardAgainstInvalidDirectives($directive);
+        $this->guardAgainstInvalidValues(Arr::wrap($values));
+
+        if ($directive instanceof CspDirective) {
+            $directive = $directive->value;
+        }
+
+        if ($values === CspValue::NO_VALUE) {
+            $this->directives[$directive][] = CspValue::NO_VALUE;
+
+            return $this;
+        }
+
+        $values = array_filter(
+            Arr::flatten(
+                array_map(fn ($value) => explode(' ', is_string($value) ? $value : $value->value), Arr::wrap($values))
+            )
+        );
+
+        if ($this->containsEnumValue(CspKeyword::None, $values)) {
+            $this->directives[$directive] = [$this->sanitizeValue(CspKeyword::None)];
+
+            return $this;
+        }
+
+        $this->directives[$directive] = array_filter($this->directives[$directive] ?? [], function ($value) {
+            return $value !== $this->sanitizeValue(CspKeyword::None);
+        });
+
+        foreach ($values as $value) {
+            $sanitizedValue = $this->sanitizeValue($value);
+
+            if (! in_array($sanitizedValue, $this->directives[$directive] ?? [], true)) {
+                $this->directives[$directive][] = $sanitizedValue;
+            }
+        }
+
+        return $this;
+    }
+
+    public function reportOnly(): self
+    {
+        $this->reportOnly = true;
+
+        return $this;
+    }
+
+    public function enforce(): self
+    {
+        $this->reportOnly = false;
+
+        return $this;
+    }
+
+    public function reportTo(string $uri): self
+    {
+        $this->directives[CspDirective::Report->value] = [$uri];
+
+        return $this;
+    }
+
+    public function shouldBeApplied(Request $request, Response $response): bool
+    {
+        return config('csp.enabled');
+    }
+
+    public function addNonceForDirective(string|CspDirective $directive): self
+    {
+        return $this->addDirective(
+            $directive,
+            "'nonce-" . app('csp-nonce') . "'",
+        );
+    }
+
+    public function upgradeInsecureRequests(): self
+    {
+        return $this->addDirective(CspDirective::UpgradeInsecureRequests, CspValue::NO_VALUE);
+    }
+
+    public function blockAllMixedContent(): self
+    {
+        return $this->addDirective(CspDirective::BlockAllMixedContent, CspValue::NO_VALUE);
+    }
+
+    public function prepareHeader(): string
+    {
+        $this->configure();
+
+        return $this->reportOnly
+            ? 'Content-Security-Policy-Report-Only'
+            : 'Content-Security-Policy';
+    }
+
+    public function applyTo(Response $response): void
+    {
+        $headerName = $this->prepareHeader();
+
+        if ($response->headers->has($headerName)) {
+            return;
+        }
+
+        $response->headers->set($headerName, (string) $this);
+    }
+
+    public function __toString(): string
+    {
+        return collect($this->directives)
+            ->map(function (array $values, string $directive) {
+                $valueString = implode(' ', $values);
+
+                return empty($valueString) ? $directive : "{$directive} {$valueString}";
+            })
+            ->implode(';');
+    }
+
+    protected function isHash(string $value): bool
+    {
+        $acceptableHashingAlgorithms = [
+            'sha256-',
+            'sha384-',
+            'sha512-',
+        ];
+
+        return Str::startsWith($value, $acceptableHashingAlgorithms);
+    }
+
+    protected function isKeyword(string $value): bool
+    {
+        return CspKeyword::tryFrom($value) !== null;
+    }
+
+    protected function sanitizeValue(string|CspKeyword|CspScheme $value): string
+    {
+        if (! is_string($value)) {
+            $value = $value->value;
+        }
+
+        if ($this->isKeyword($value) || $this->isHash($value)) {
+            return "'{$value}'";
+        }
+
+        return $value;
+    }
+
+    protected function guardAgainstInvalidDirectives(string|CspDirective $directive): void
+    {
+        if ($directive instanceof CspDirective) {
+            return;
+        }
+
+        if (! CspDirective::tryFrom($directive)) {
+            throw InvalidCspDirective::notSupported($directive);
+        }
+    }
+
+    protected function guardAgainstInvalidValues(array $values): void
+    {
+        if ($this->containsEnumValue(CspKeyword::None, $values) && count($values) > 1) {
+            throw InvalidCspValueSet::noneMustBeOnlyValue();
+        }
+    }
+
+    /**
+     * We are checking for either the presence of the enum instance or the enum value
+     * to allow more flexibility when adding directives.
+     */
+    protected function containsEnumValue(CspDirective|CspKeyword $enum, array $values): bool
+    {
+        if (in_array($enum, $values, true)) {
+            return true;
+        }
+
+        return in_array($enum->value, $values, true);
+    }
+}

--- a/src/Csp/PolicyFactory.php
+++ b/src/Csp/PolicyFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Csp;
+
+use Rawilk\LaravelBase\Csp\Policies\CspPolicy;
+use Rawilk\LaravelBase\Exceptions\InvalidCspPolicy;
+
+/** @internal */
+final class PolicyFactory
+{
+    public static function create(string $className): CspPolicy
+    {
+        $policy = app($className);
+
+        if (! is_a($policy, CspPolicy::class, true)) {
+            throw InvalidCspPolicy::create($policy);
+        }
+
+        if (! empty(config('csp.report_uri'))) {
+            $policy->reportTo(config('csp.report_uri'));
+        }
+
+        return $policy;
+    }
+}

--- a/src/Csp/helpers.php
+++ b/src/Csp/helpers.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\LaravelBase\Csp\PolicyFactory;
+use Rawilk\LaravelBase\Exceptions\MissingCspMetaTagPolicy;
+
+if (! function_exists('cspNonce')) {
+    function cspNonce(): string
+    {
+        return app('csp-nonce');
+    }
+}
+
+if (! function_exists('cspMetaTag')) {
+    function cspMetaTag(string $policyClass): string
+    {
+        if ($policyClass === '') {
+            throw MissingCspMetaTagPolicy::create();
+        }
+
+        if (! config('csp.enabled')) {
+            return '';
+        }
+
+        $policy = PolicyFactory::create($policyClass);
+
+        return "<meta http-equiv=\"{$policy->prepareHeader()}\" content=\"{$policy->__toString()}\">";
+    }
+}

--- a/src/Exceptions/InvalidCspDirective.php
+++ b/src/Exceptions/InvalidCspDirective.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Exceptions;
+
+use Exception;
+
+class InvalidCspDirective extends Exception
+{
+    public static function notSupported(string $directive): self
+    {
+        return new self("The directive `{$directive}` is not valid in a CSP header.");
+    }
+}

--- a/src/Exceptions/InvalidCspPolicy.php
+++ b/src/Exceptions/InvalidCspPolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Exceptions;
+
+use Exception;
+use Rawilk\LaravelBase\Csp\Policies\CspPolicy;
+
+class InvalidCspPolicy extends Exception
+{
+    public static function create(object $class): self
+    {
+        $className = $class::class;
+
+        return new self("The CSP class `{$className}` is not valid. A valid policy extends " . CspPolicy::class);
+    }
+}

--- a/src/Exceptions/InvalidCspValueSet.php
+++ b/src/Exceptions/InvalidCspValueSet.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Exceptions;
+
+use Exception;
+
+class InvalidCspValueSet extends Exception
+{
+    public static function noneMustBeOnlyValue(): self
+    {
+        return new self('The keyword `none` can only be used on its own');
+    }
+}

--- a/src/Exceptions/MissingCspMetaTagPolicy.php
+++ b/src/Exceptions/MissingCspMetaTagPolicy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\LaravelBase\Exceptions;
+
+use Exception;
+
+class MissingCspMetaTagPolicy extends Exception
+{
+    public static function create(): self
+    {
+        return new self('The [@cspMetaTag] directive expects to be passed a valid policy class name');
+    }
+}

--- a/tests/Csp/AddCspHeadersTest.php
+++ b/tests/Csp/AddCspHeadersTest.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Support\Facades\Route;
+use Rawilk\LaravelBase\Csp\Enums\CspDirective;
+use Rawilk\LaravelBase\Csp\Enums\CspKeyword;
+use Rawilk\LaravelBase\Csp\Enums\CspScheme;
+use Rawilk\LaravelBase\Csp\Enums\CspValue;
+use Rawilk\LaravelBase\Csp\Middleware\AddCspHeaders;
+use Rawilk\LaravelBase\Csp\Policies\CspPolicy;
+use Rawilk\LaravelBase\Exceptions\InvalidCspDirective;
+use Rawilk\LaravelBase\Exceptions\InvalidCspPolicy;
+use Rawilk\LaravelBase\Exceptions\InvalidCspValueSet;
+use Symfony\Component\HttpFoundation\HeaderBag;
+
+const CSP_HEADER = 'Content-Security-Policy';
+
+const CSP_REPORT_HEADER = 'Content-Security-Policy-Report-Only';
+
+beforeEach(function () {
+    app(Kernel::class)->pushMiddleware(AddCspHeaders::class);
+
+    Route::get('test-route', function (): string {
+        return 'ok';
+    });
+});
+
+// Helpers
+function getResponseHeaders(string $url = 'test-route'): HeaderBag
+{
+    return test()
+        ->get($url)
+        ->assertSuccessful()
+        ->headers;
+}
+
+it('wil set csp headers with default configuration', function () {
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toContain("default-src 'self';")
+        ->and($headers->get(CSP_REPORT_HEADER))->toBeNull();
+});
+
+it('can set report only csp headers', function () {
+    config([
+        'csp.report_only' => true,
+    ]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_REPORT_HEADER))->toContain("default-src 'self';")
+        ->and($headers->get(CSP_HEADER))->toBeNull();
+});
+
+it('will not set any headers if not enabled in the config', function () {
+    config([
+        'csp.enabled' => false,
+    ]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toBeNull()
+        ->and($headers->get(CSP_REPORT_HEADER))->toBeNull();
+});
+
+test('a report uri can be set in the config', function () {
+    config([
+        'csp.report_uri' => 'https://report-uri.com',
+    ]);
+
+    $headers = getResponseHeaders();
+
+    $cspHeader = $headers->get(CSP_HEADER);
+
+    expect($cspHeader)->toContain('report-uri https://report-uri.com');
+});
+
+it('will throw an exception when using an invalid policy class', function () {
+    withoutExceptionHandling();
+
+    $invalidPolicyClassName = new class
+    {
+    };
+
+    config(['csp.policy' => $invalidPolicyClassName::class]);
+
+    getResponseHeaders();
+})->throws(InvalidCspPolicy::class);
+
+it('will throw an exception when passing none with other values', function () {
+    withoutExceptionHandling();
+
+    $invalidPolicy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Connect, [CspKeyword::None, 'connect']);
+        }
+    };
+
+    config(['csp.policy' => $invalidPolicy::class]);
+
+    getResponseHeaders();
+})->throws(InvalidCspValueSet::class);
+
+it('will throw an exception when using an invalid csp directive', function () {
+    withoutExceptionHandling();
+
+    $invalidPolicy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective('invalid-directive', 'value');
+        }
+    };
+
+    config(['csp.policy' => $invalidPolicy::class]);
+
+    getResponseHeaders();
+})->throws(InvalidCspDirective::class);
+
+it('can use multiple values for the same directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Frame, 'src-1')
+                ->addDirective(CspDirective::Frame, 'src-2')
+                ->addDirective(CspDirective::FormAction, 'action-1')
+                ->addDirective(CspDirective::FormAction, 'action-2');
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('frame-src src-1 src-2;form-action action-1 action-2');
+});
+
+test('none overrides other values for the same directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Connect, 'connect-1')
+                ->addDirective(CspDirective::Frame, 'src-1')
+                ->addDirective(CspDirective::Connect, CspKeyword::None);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('connect-src \'none\';frame-src src-1');
+});
+
+test('values override none value for same directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Connect, CspKeyword::None)
+                ->addDirective(CspDirective::Frame, 'src-1')
+                ->addDirective(CspDirective::Connect, CspKeyword::Self);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('connect-src \'self\';frame-src src-1');
+});
+
+test('a policy can configure itself to be put in report only mode', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->reportOnly();
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toBeNull()
+        ->and($headers->get(CSP_REPORT_HEADER))->not()->toBeNull();
+});
+
+it('can add multiple values for the same directive at the same time', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Frame, ['src-1', 'src-2']);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('frame-src src-1 src-2');
+});
+
+it('will automatically quote special directive values', function () {
+   $policy = new class extends CspPolicy
+   {
+       public function configure(): void
+       {
+           $this->addDirective(CspDirective::Script, [CspKeyword::Self]);
+       }
+   };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual("script-src 'self'");
+});
+
+it('will automatically quote hashed values', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Script, [
+                'sha256-hash1',
+                'sha384-hash2',
+                'sha512-hash3',
+            ]);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual("script-src 'sha256-hash1' 'sha384-hash2' 'sha512-hash3'");
+});
+
+it('will automatically check values when they are given in a single string separated by spaces', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Script, 'sha256-hash1 ' . CspKeyword::Self->value . ' source');
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual("script-src 'sha256-hash1' 'self' source");
+});
+
+it('will not output the same directive values twice', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Script, [
+                CspKeyword::Self,
+                CspKeyword::Self,
+            ]);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual("script-src 'self'");
+});
+
+test('route middleware will override global middleware for that route', function () {
+    withoutExceptionHandling();
+
+    $customPolicy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Base, 'custom-policy');
+        }
+    };
+
+    Route::get('other-route', fn () => 'ok')->middleware(AddCspHeaders::class . ':' . $customPolicy::class);
+
+    $headers = getResponseHeaders('other-route');
+
+    expect($headers->get(CSP_HEADER))->toEqual('base-uri custom-policy');
+});
+
+it('will handle scheme values', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Img, [
+                CspScheme::Data,
+                CspScheme::Https,
+                CspScheme::Ws,
+                CspScheme::Wss,
+            ]);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('img-src data: https: ws: wss:');
+});
+
+it('can use an empty value for a directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::UpgradeInsecureRequests, CspValue::NO_VALUE)
+                ->addDirective(CspDirective::BlockAllMixedContent, CspValue::NO_VALUE);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('upgrade-insecure-requests;block-all-mixed-content');
+});
+
+it('provides helper functions for empty value directives', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->upgradeInsecureRequests()
+                ->blockAllMixedContent();
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('upgrade-insecure-requests;block-all-mixed-content');
+});
+
+it('can use a nonce value for a directive', function () {
+    $nonce = cspNonce();
+
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addNonceForDirective(CspDirective::Script);
+        }
+    };
+
+    config(['csp.policy' => $policy::class]);
+
+    $headers = getResponseHeaders();
+
+    expect($headers->get(CSP_HEADER))->toEqual('script-src \'nonce-' . $nonce . '\'');
+});

--- a/tests/Csp/Blade/MetaTagTest.php
+++ b/tests/Csp/Blade/MetaTagTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\View\ViewException;
+use Rawilk\LaravelBase\Csp\Enums\CspDirective;
+use Rawilk\LaravelBase\Csp\Enums\CspKeyword;
+use Rawilk\LaravelBase\Csp\Enums\CspScheme;
+use Rawilk\LaravelBase\Csp\Enums\CspValue;
+use Rawilk\LaravelBase\Csp\Policies\BasicCsp;
+use Rawilk\LaravelBase\Csp\Policies\CspPolicy;
+
+const CSP_HEADER = 'Content-Security-Policy';
+
+const CSP_REPORT_HEADER = 'Content-Security-Policy-Report-Only';
+
+it('will output csp headers with the default configuration', function () {
+    expect(renderView())
+        ->toMatch(metaTagRegex())
+        ->toContain("default-src 'self';");
+});
+
+it('can set report only csp meta tags', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->reportOnly();
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toMatch(metaTagRegex(CSP_REPORT_HEADER));
+});
+
+it('wont output any meta tag if not enabled in the config', function () {
+    config([
+        'csp.enabled' => false,
+    ]);
+
+    expect(renderView())->toContain('<head></head>');
+});
+
+test('a report uri can be set in the config', function () {
+    config(['csp.report_uri' => 'https://report-uri.com']);
+
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->reportOnly();
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toContain('report-uri https://report-uri.com');
+});
+
+it('will throw an exception when passing no policy class', function () {
+    renderView('');
+})->throws(ViewException::class, 'The [@cspMetaTag] directive expects to be passed a valid policy class name');
+
+it('will throw an exception for an invalid policy class', function () {
+    $invalidPolicyClassName = new class
+    {
+    };
+
+    renderView($invalidPolicyClassName::class);
+})->throws(ViewException::class, 'A valid policy extends ' . CspPolicy::class);
+
+it('will throw an exception when passing none with other values', function () {
+    $invalidPolicy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this->addDirective(CspDirective::Connect, [CspKeyword::None, 'connect']);
+        }
+    };
+
+    renderView($invalidPolicy::class);
+})->throws(ViewException::class, 'The keyword `none` can only be used on its own');
+
+it('can use multiple values for the same directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Frame, 'src-1')
+                ->addDirective(CspDirective::Frame, 'src-2')
+                ->addDirective(CspDirective::FormAction, 'action-1')
+                ->addDirective(CspDirective::FormAction, 'action-2');
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent('frame-src src-1 src-2;form-action action-1 action-2');
+});
+
+test('none overrides other values for the same directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Connect, 'connect-1')
+                ->addDirective(CspDirective::Frame, 'src-1')
+                ->addDirective(CspDirective::Connect, CspKeyword::None);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent('connect-src \'none\';frame-src src-1');
+});
+
+test('values override none value for the same directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Connect, CspKeyword::None)
+                ->addDirective(CspDirective::Frame, 'src-1')
+                ->addDirective(CspDirective::Connect, CspKeyword::Self);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent('connect-src \'self\';frame-src src-1');
+});
+
+it('can add multiple values for the same directive at one time', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Frame, ['src-1', 'src-2']);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent('frame-src src-1 src-2');
+});
+
+it('will automatically quote special directive values', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Script, [CspKeyword::Self]);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent("script-src 'self'");
+});
+
+it('will automatically quote hashed values', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Script, [
+                    'sha256-hash1',
+                    'sha384-hash2',
+                    'sha512-hash3',
+                ]);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent("script-src 'sha256-hash1' 'sha384-hash2' 'sha512-hash3'");
+});
+
+it('will automatically check values when they are given in a single string separated by spaces', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Script, 'sha256-hash1 ' . CspKeyword::Self->value . ' source');
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent("script-src 'sha256-hash1' 'self' source");
+});
+
+it('will not output the same directive values twice', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Script, [CspKeyword::Self, CspKeyword::Self]);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent("script-src 'self'");
+});
+
+it('will handle scheme values', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::Img, [
+                    CspScheme::Data,
+                    CspScheme::Https,
+                    CspScheme::Ws,
+                ]);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent('img-src data: https: ws:');
+});
+
+it('can use an empty value for a directive', function () {
+    $policy = new class extends CspPolicy
+    {
+        public function configure(): void
+        {
+            $this
+                ->addDirective(CspDirective::UpgradeInsecureRequests, CspValue::NO_VALUE)
+                ->addDirective(CspDirective::BlockAllMixedContent, CspValue::NO_VALUE);
+        }
+    };
+
+    expect(renderView($policy::class))
+        ->toHaveMetaContent('upgrade-insecure-requests;block-all-mixed-content');
+});
+
+// Helpers
+function renderView(string $policyName = BasicCsp::class)
+{
+    return app('view')
+        ->file(__DIR__ . '/../fixtures/csp-meta-tags.blade.php')
+        ->with('policyName', $policyName)
+        ->render();
+}
+
+function metaTagRegex(string $headerName = CSP_HEADER, string $content = '.*'): string
+{
+    return "/<head><meta http-equiv=\"{$headerName}\" content=\"{$content}\"><\/head>/";
+}

--- a/tests/Csp/Blade/NonceTest.php
+++ b/tests/Csp/Blade/NonceTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+it('will output the correct nonce', function () {
+    $nonce = cspNonce();
+
+    $view = app('view')
+        ->file(__DIR__ . '/../fixtures/view.blade.php')
+        ->render();
+
+    expect(trim($view))->toBe('<script nonce="' . $nonce . '"></script>');
+});

--- a/tests/Csp/NonceTest.php
+++ b/tests/Csp/NonceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\LaravelBase\Csp\Nonce\RandomStringNonceGenerator;
+
+it('will generate the same result', function () {
+    $nonce = cspNonce();
+
+    foreach (range(1, 5) as $i) {
+        expect(cspNonce())->toBe($nonce);
+    }
+});
+
+test('RandomStringNonceGenerator will generate a random string', function () {
+    $nonce = app(RandomStringNonceGenerator::class)->generate();
+
+    $this->assertEquals(strlen($nonce), 32);
+});

--- a/tests/Csp/fixtures/csp-meta-tags.blade.php
+++ b/tests/Csp/fixtures/csp-meta-tags.blade.php
@@ -1,0 +1,1 @@
+<head>@cspMetaTag($policyName)</head>

--- a/tests/Csp/fixtures/view.blade.php
+++ b/tests/Csp/fixtures/view.blade.php
@@ -1,0 +1,1 @@
+<script @nonce></script>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,22 @@
 <?php
 
+use function Orchestra\Testbench\artisan;
 use Rawilk\LaravelBase\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
+
+// Make sure view is compiled fresh each run in blade tests.
+uses()->beforeEach(fn () => artisan($this, 'view:clear'))->in(
+    'Csp/Blade',
+);
+
+expect()->extend('toHaveMetaContent', function ($value) {
+    return expect($this->value)
+        ->toMatch('/<meta http-equiv="[\w-]+" content="' . preg_quote($value) . '">/');
+});
+
+// Helpers
+function withoutExceptionHandling(): void
+{
+    test()->withoutExceptionHandling();
+}


### PR DESCRIPTION
Add a fluent and configurable api for defining a content security policy, and add a middleware that will generate the necessary headers for it. Heavily based off the [laravel-csp](https://github.com/spatie/laravel-csp) package.
